### PR TITLE
Schedule tweet

### DIFF
--- a/scheduled_tweets.json
+++ b/scheduled_tweets.json
@@ -1,0 +1,7 @@
+[
+  {
+    "text": "This is a scheduled tweet! 🕐",
+    "schedule_time": "2025-09-30T17:10:00-10:00",
+    "id": "tweet_1759287922270118906"
+  }
+]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Schedule tweets for future posting via a new --schedule option.
  - Manage scheduled tweets with new commands: list, cancel, and a background scheduler daemon.
  - Supports flexible date/time input formats (full date-time, date-only variants, and time-only).
  - Persists scheduled tweets locally so they survive restarts, with unique IDs for reference.
  - Lists scheduled tweets with status (Pending/Overdue), text, image (if any), and schedule time.
  - Posts due tweets automatically, including optional media uploads.
  - Added user-facing help and messages for scheduling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->